### PR TITLE
Add back circleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2
+
+buildSteps: &buildSteps
+  - checkout
+  - run:
+      name: install-npm
+      command: npm install
+  - run:
+      name: test
+      command: npm test
+
+jobs:
+  'node-8':
+    docker:
+      - image: circleci/node:8
+    steps: *buildSteps
+
+  'node-10':
+    docker:
+      - image: circleci/node:10
+    steps: *buildSteps
+
+  'node-12':
+    docker:
+      - image: circleci/node:12
+    steps: *buildSteps
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - 'node-8'
+      - 'node-10'
+      - 'node-12'

--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,3 @@
+---
+npm:
+  platforms: []


### PR DESCRIPTION
I noticed the README PR didn't run the full tests. It looks like during the migration, the CircleCI tests got dropped on accident. This adds them back.