### PR TITLE
Provide low memory alternatives for query and Blueprint.reproduce operations

### DIFF
--- a/lib/blueprint.ts
+++ b/lib/blueprint.ts
@@ -22,7 +22,7 @@ import Contract from './contract';
 import { parse } from './cardinality';
 import { BLUEPRINT, BlueprintLayout, BlueprintObject } from './types/types';
 import {
-	iterableCartesianProductWith,
+	cartesianProductWith,
 	flatten as flattenIterator,
 	filter as filterIterator,
 } from './utils';
@@ -418,7 +418,7 @@ export default class Blueprint extends Contract {
 			[] as Contract[][][],
 		);
 
-		const productIterator = iterableCartesianProductWith<
+		const productIterator = cartesianProductWith<
 			Contract[],
 			Contract | Contract[]
 		>(

--- a/lib/blueprint.ts
+++ b/lib/blueprint.ts
@@ -21,7 +21,11 @@ import { compare } from 'semver';
 import Contract from './contract';
 import { parse } from './cardinality';
 import { BLUEPRINT, BlueprintLayout, BlueprintObject } from './types/types';
-import { cartesianProductWith } from './utils';
+import {
+	iterableCartesianProductWith,
+	flatten as flattenIterator,
+	filter as filterIterator,
+} from './utils';
 
 export default class Blueprint extends Contract {
 	/**
@@ -346,15 +350,60 @@ export default class Blueprint extends Contract {
 	 *   'arch.sw': 1
 	 * })
 	 *
-	 * const contexts = blueprint.reproduce(contract)
-	 *
+	 * const contexts = blueprint.reproduceAsIterable(contract)
 	 * contexts.forEach((context) => {
-	 *   console.log(context.toJSON())
+	 *   console.log(context.toJSON());
 	 * })
 	 */
-	reproduce(contract: Contract): Contract[] {
-		const layout = this.metadata.layout;
+	reproduce(contract: Contract): Contract[];
 
+	/**
+	 * @summary Reproduce the blueprint in a universe and return as an iterable
+	 * @function
+	 * @name module:contrato.Blueprint#reproduce
+	 * @public
+	 *
+	 * @description
+	 * This method will generate a set of contexts that consist of
+	 * every possible valid combination that matches the blueprint
+	 * layout. It uses depth first search to calculate the product of
+	 * contract combinations and returns the results as an iterable.
+	 * This allows to reduce the memory usage when dealing with a large
+	 * universe of contracts.
+	 *
+	 * @param {Object} contract - contract
+	 * @param {boolean} asIterable - flag to indicate that the result should be an iterable
+	 * @returns {Iterable<Object>} - an iterable over the valid contexts
+	 *
+	 * @example
+	 * const contract = new Contract({ ... })
+	 * contract.addChildren([ ... ])
+	 *
+	 * const blueprint = new Blueprint({
+	 *   'hw.device-type': 1,
+	 *   'arch.sw': 1
+	 * })
+	 *
+	 * const contexts = blueprint.reproduceAsIterable(contract)
+	 * for (const context of contexts) {
+	 *   console.log(context.toJSON());
+	 * }
+	 */
+	reproduce(contract: Contract, asIterable: true): IterableIterator<Contract>;
+
+	reproduce(
+		contract: Contract,
+		asIterable?: boolean,
+	): Contract[] | IterableIterator<Contract>;
+	reproduce(
+		contract: Contract,
+		asIterable = false,
+	): IterableIterator<Contract> | Contract[] {
+		if (!asIterable) {
+			return [...this.reproduce(contract, true)];
+		}
+
+		const layout = this.metadata.layout;
 		const combinations = reduce(
 			layout.finite.selectors,
 			(accumulator, value) => {
@@ -369,7 +418,10 @@ export default class Blueprint extends Contract {
 			[] as Contract[][][],
 		);
 
-		const product = cartesianProductWith<Contract[], Contract | Contract[]>(
+		const productIterator = iterableCartesianProductWith<
+			Contract[],
+			Contract | Contract[]
+		>(
 			combinations,
 			(accumulator, element) => {
 				if (accumulator instanceof Contract) {
@@ -393,6 +445,7 @@ export default class Blueprint extends Contract {
 					return prodContext;
 				}
 
+				// If the accumulator is an array of contracts
 				const context = new Contract(this.raw.skeleton, {
 					hash: false,
 				});
@@ -404,7 +457,7 @@ export default class Blueprint extends Contract {
 			[[]],
 		);
 
-		return flatten(product).filter((context: any) => {
+		return filterIterator(flattenIterator(productIterator), (context: any) => {
 			const references = context.getChildrenCrossReferencedContracts({
 				from: contract,
 				types: layout.infinite.types,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -33,7 +33,8 @@ export const query = (
 	universe: Contract,
 	layout: BlueprintLayout,
 	skeleton: object,
-) => new Blueprint(layout, skeleton).reproduce(universe);
+	asIterable = false,
+) => new Blueprint(layout, skeleton).reproduce(universe, asIterable);
 
 export const sequence = (
 	universe: Contract,

--- a/lib/partials.ts
+++ b/lib/partials.ts
@@ -96,12 +96,16 @@ export const findPartial = (
 			}),
 		(structureReferences: string[][]) =>
 			thru(structureReferences, (combinations) => {
-				const products = cartesianProductWith<string, string[]>(
-					combinations,
-					(accumulator: string[], element: string) =>
-						accumulator.concat([element]),
-					[[]],
-				);
+				const products = [
+					...cartesianProductWith<string, string[]>(
+						combinations,
+						(accumulator: string[], element: string) => {
+							accumulator.push(element);
+							return accumulator;
+						},
+						[[]],
+					),
+				];
 
 				const slices = reduce(
 					range(options.structure.length, 1, -1),

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -112,6 +112,58 @@ export const setMap = <T, V>(set1: Set<T>, iteratee: (arg0: T) => V): V[] => {
 	return result;
 };
 
+/**
+ * @summary Perform a depth 1 flatten operation on an iterable
+ * @function
+ * @memberof module:utils
+ * @public
+ *
+ * @description
+ * This function performs the equivalent of Array.flat but for an iterable input.
+ * Given an iterable of arrays, this function will return an iterator over the elements of the arrays.
+ *
+ * @param {Iterable} iterable - iterator
+ * @returns {Iterable} mapped iterator
+ */
+export function* flatten<T>(iterable: Iterable<T | T[]>): IterableIterator<T> {
+	for (const it of iterable) {
+		if (!Array.isArray(it)) {
+			yield it;
+			continue;
+		}
+
+		for (const item of it) {
+			yield item;
+		}
+	}
+}
+
+/**
+ * @summary Perform a filter operation on an iterable input
+ * @function
+ * @memberof module:utils
+ * @public
+ *
+ * @description
+ * This function performs the equivalent of Array.filter() but for an iterable input.
+ * Given an iterable and a predicate function, this function will return an iterator
+ * over the elements of the iterable that satisfy the predicate.
+ *
+ * @param {Iterable} iterable - iterator
+ * @param {Function} predicate - predicate function
+ * @returns {Iterable} filtered iterator
+ */
+export function* filter<T>(
+	iterable: Iterable<T>,
+	predicate: (t: T) => boolean,
+): IterableIterator<T> {
+	for (const it of iterable) {
+		if (predicate(it)) {
+			yield it;
+		}
+	}
+}
+
 function* nextCartesianProduct<T, V>(
 	sets: T[][],
 	iteratee: (arg0: V, arg1: T) => V | undefined,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -208,7 +208,7 @@ function* nextCartesianProduct<T, V>(
 }
 
 /**
- * @summary Compute the cartisian product of a set of sets and return an iterator over the results
+ * @summary Compute the cartisian product of a set of sets and return an iterable over the results
  * @function
  * @memberof module:utils
  * @public
@@ -245,7 +245,7 @@ function* nextCartesianProduct<T, V>(
  * > [ 2, 4 ]
  */
 
-export function* iterableCartesianProductWith<T, V>(
+export function* cartesianProductWith<T, V>(
 	sets: T[][],
 	iteratee: (arg0: V, arg1: T) => V | undefined,
 	init: V[],
@@ -254,51 +254,6 @@ export function* iterableCartesianProductWith<T, V>(
 		yield* nextCartesianProduct(sets, iteratee, combination, 0, 0);
 	}
 }
-
-/**
- * @summary Compute the cartesian product of a set of sets
- * @function
- * @memberof module:utils
- * @public
- *
- * @description
- * This function combines the first two sets, and then combines
- * the resulting set if the third set, and so on.
- *
- * The iteratee function is called every step, and clients may
- * return undefined to stop evaluating a possible combination.
- *
- * This function calculates all possible combinations before returning, which means
- * that for large sets it may use a lot of memory. If this is a concern, use the `iterableCartesianProductWith`
- * function instead;
- *
- * @param {Array[]} sets - sets of sets
- * @param {Function} iteratee - iteratee (accumulator, element)
- * @returns {Array[]} cartesian product
- *
- * @example
- * const product = utils.cartesianProductWith([
- *   [ 1, 2 ],
- *   [ 3, 4 ]
- * ], (accumulator, element) => {
- *   return accumulator.concat([ element ])
- * })
- *
- * console.log(product)
- * > [
- * >   [ 1, 3 ],
- * >   [ 1, 4 ],
- * >   [ 2, 3 ],
- * >   [ 2, 4 ]
- * > ]
- */
-export const cartesianProductWith = <T, V>(
-	sets: T[][],
-	iteratee: (arg0: V, arg1: T) => V | undefined,
-	init: V[],
-): V[] => {
-	return [...iterableCartesianProductWith(sets, iteratee, init)];
-};
 
 /**
  * @summary Strip extra blank lines from a multi-line text

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "openapi-typescript": "^3.2.4",
     "rimraf": "^3.0.2",
     "ts-node": "^8.10.1",
-    "typedoc": "^0.20.36",
-    "typescript": "^3.9.3"
+    "typedoc": "^0.23.28",
+    "typescript": "^4.9.5"
   },
   "versionist": {
     "publishedAt": "2023-03-30T21:47:44.134Z"

--- a/tests/utils/cartesian-product-with.spec.ts
+++ b/tests/utils/cartesian-product-with.spec.ts
@@ -82,6 +82,41 @@ describe('cartesianProductWith', () => {
 		]);
 	});
 
+	it('should calculate the cartesian product of three string sets with different lengths', () => {
+		const product = cartesianProductWith(
+			[
+				['hello', 'hi', 'hey'],
+				['!', ','],
+				['there', 'world', 'yo'],
+			],
+			(accumulator: string[], element: string) => {
+				return _.concat(accumulator, [element]);
+			},
+			[[]],
+		);
+
+		expect(product).deep.equal([
+			['hello', '!', 'there'],
+			['hello', '!', 'world'],
+			['hello', '!', 'yo'],
+			['hello', ',', 'there'],
+			['hello', ',', 'world'],
+			['hello', ',', 'yo'],
+			['hi', '!', 'there'],
+			['hi', '!', 'world'],
+			['hi', '!', 'yo'],
+			['hi', ',', 'there'],
+			['hi', ',', 'world'],
+			['hi', ',', 'yo'],
+			['hey', '!', 'there'],
+			['hey', '!', 'world'],
+			['hey', '!', 'yo'],
+			['hey', ',', 'there'],
+			['hey', ',', 'world'],
+			['hey', ',', 'yo'],
+		]);
+	});
+
 	it('should be able to discard combinations by returning undefined', () => {
 		const product = cartesianProductWith(
 			[

--- a/tests/utils/cartesian-product-with.spec.ts
+++ b/tests/utils/cartesian-product-with.spec.ts
@@ -18,7 +18,7 @@ describe('cartesianProductWith', () => {
 			[[]],
 		);
 
-		expect(product).to.deep.equal([]);
+		expect([...product]).to.deep.equal([]);
 	});
 
 	it('should perform a cartesian product of a valid and an empty set', () => {
@@ -30,7 +30,7 @@ describe('cartesianProductWith', () => {
 			[[]],
 		);
 
-		expect(product).to.deep.equal([['foo']]);
+		expect([...product]).to.deep.equal([['foo']]);
 	});
 
 	it('should perform a cartesian product of no sets', () => {
@@ -42,7 +42,7 @@ describe('cartesianProductWith', () => {
 			[[]],
 		);
 
-		expect(product).to.deep.equal([]);
+		expect([...product]).to.deep.equal([]);
 	});
 
 	it('should perform a cartesian product of a one element set', () => {
@@ -54,7 +54,7 @@ describe('cartesianProductWith', () => {
 			[[]],
 		);
 
-		expect(product).to.deep.equal([['foo']]);
+		expect([...product]).to.deep.equal([['foo']]);
 	});
 
 	it('should calculate the cartesian product of two string sets', () => {
@@ -69,7 +69,7 @@ describe('cartesianProductWith', () => {
 			[[]],
 		);
 
-		expect(product).deep.equal([
+		expect([...product]).deep.equal([
 			['hello', 'there'],
 			['hello', 'world'],
 			['hello', 'yo'],
@@ -95,7 +95,7 @@ describe('cartesianProductWith', () => {
 			[[]],
 		);
 
-		expect(product).deep.equal([
+		expect([...product]).deep.equal([
 			['hello', '!', 'there'],
 			['hello', '!', 'world'],
 			['hello', '!', 'yo'],
@@ -141,7 +141,7 @@ describe('cartesianProductWith', () => {
 			[[]],
 		);
 
-		expect(product).deep.equal([
+		expect([...product]).deep.equal([
 			['hello', 'world'],
 			['hi', 'there'],
 			['hi', 'yo'],
@@ -176,7 +176,7 @@ describe('cartesianProductWith', () => {
 			[[]],
 		);
 
-		expect(product).deep.equal([
+		expect([...product]).deep.equal([
 			[1, 4, 7],
 			[1, 4, 8],
 			[1, 4, 9],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,12 +8,10 @@
 		"removeComments": true,
 		"sourceMap": true,
 		"strict": true,
-		"target": "es2015",
+		"target": "es2022",
 		"declaration": true,
 		"skipLibCheck": true,
 		"resolveJsonModule": true
 	},
-	"include": [
-		"lib/**/*.ts"
-	]
+	"include": ["lib/**/*.ts"]
 }


### PR DESCRIPTION
The `Blueprint.reproduce` operation, which is used to query a contract universe given a selector and a layout, calculates the whole universe of contracts as a Cartesian product and then calculates the list of resulting contracts while keeping all this information in memory. For large contract sets, this can result in too large memory usage. 

This PR is providing low memory alternatives to these operations, using iterators, so the results can be consumed as soon as they are ready

- [x] Use depth first search to calculate cartesian product
- [x] Create iterator alternatives to flatten and filter operations
- [x] Add option to return iterable to Blueprint.reproduce
- [x] Update query function to return an iterator instead of an array if requested